### PR TITLE
Use Local Time instead of UTC for Reminders

### DIFF
--- a/src/SFA.DAS.ApprenticeProgress.Application/Tasks/Queries/GetTaskReminders/GetTaskRemindersQueryHandler.cs
+++ b/src/SFA.DAS.ApprenticeProgress.Application/Tasks/Queries/GetTaskReminders/GetTaskRemindersQueryHandler.cs
@@ -37,9 +37,9 @@ namespace SFA.DAS.ApprenticeProgress.Application.Queries
                 var reminderTime = task.DueDate.GetValueOrDefault().AddMinutes(-minuteBeforeDueDate);
 
                 var timeToCheckFrom = DateTime.UtcNow.AddDays(-1);
-                var timeToCheckTo = DateTime.UtcNow.AddMinutes(1);
-
-                if (timeToCheckFrom <= reminderTime && timeToCheckTo > reminderTime)
+                var timeToCheckTo = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow.AddMinutes(1), TimeZoneInfo.Local);
+                
+                if (timeToCheckFrom <= reminderTime && timeToCheckTo >= reminderTime)
                 {
                     reminders.Add(new TaskReminderModel()
                     {


### PR DESCRIPTION
Time for reminders was being set in UTC which was reducing the check for time by an hour, I have amended this by adding a timezone.local check so this check is processing correctly